### PR TITLE
Add a basic rendering scenario

### DIFF
--- a/features/ambiguous_characters.feature
+++ b/features/ambiguous_characters.feature
@@ -1,0 +1,40 @@
+Feature: Ambiguous characters
+  Markdown and Haml share some characters for semantics
+  Hamdown defines the semantics of those characters
+  
+  Scenario: Number sign followed or not by a space
+  When I render Hamdown
+  """
+  #person236
+    # Person number 236
+    The person number 236 is the 236th person.
+  """
+  
+  Then the result is equivalent to
+  """
+  <div id="person236">
+    <h1>Person number 236</h1>
+    <p>
+      The person number 236 is the 236th person.
+    </p>
+  </div>
+  """
+  
+  Scenario: Hyphen-minus is a Haml instruction
+  When I render Hamdown
+  """
+  ## Numbers
+  - 1
+  - 2
+  - 3
+  - [4,5].each do |n|
+    %span= n
+  """
+  
+  Then the result is equivalent to
+  """
+  <h2>Numbers</h2>
+  <span>4</span>
+  <span>5</span>
+  """
+    

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -1,0 +1,22 @@
+Feature: Basic Hamdown document
+
+Scenario: A section with headings, a div, an image
+  When I render Hamdown 
+  """
+  %section.container
+    # Title
+    ## Subtitle
+    .content
+      ![](/images/main.png)
+  """
+
+  Then the result is equivalent to
+  """
+  <section class="container">
+    <h1>Title</h1>
+    <h2>Subtitle</h2>
+    <div class="content">
+      <img src="/images/main.png"/>
+    </div>
+  </section>
+  """


### PR DESCRIPTION
The first step towards a proof on concept is some kind of formal examples.

I thought about what would be a reasonable format to store (hamd -> html) expectation pairs. (1) I want both parts to be in the same file. (2) If I'm going to run these at some point, I don't want to have to code up a custom parser for these files.

Gherkin features allow both parts to be in the same file, and provides ready-made tools so that the glue around those features is easy to get. (Writing these step definitions shouldn't be long; runners already exist.) I would've liked syntax highlighting à la GFM-Markdown code blocks, but alas. (besides, that would've only worked for Html, not Hamdown yet ;o)